### PR TITLE
Correctly pass Copybara config to container

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ runs:
     - run: docker pull sharelatex/copybara:latest
       shell: bash
 
-    - run: docker run -v ~/.ssh:/root/.ssh -v ~/.gitconfig:/root/.gitconfig -v "$(pwd)":/usr/src/app -i sharelatex/copybara copybara ${{ inputs.path }}
+    - run: docker run -v ~/.ssh:/root/.ssh -v ~/.gitconfig:/root/.gitconfig -v "$(pwd)":/usr/src/app -e COPYBARA_CONFIG=${{ inputs.path }} -i sharelatex/copybara copybara
       shell: bash
 
 branding:

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ runs:
     - run: docker pull sharelatex/copybara:latest
       shell: bash
 
-    - run: docker run -v ~/.ssh:/root/.ssh -v ~/.gitconfig:/root/.gitconfig -v "$(pwd)":/usr/src/app -e COPYBARA_CONFIG=${{ inputs.path }} -i sharelatex/copybara copybara
+    - run: docker run -v ~/.ssh:/root/.ssh -v ~/.gitconfig:/root/.gitconfig -v "$(pwd)":/usr/src/app -e COPYBARA_CONFIG=${{ inputs.path }} -i sharelatex/copybara copybara || true
       shell: bash
 
 branding:


### PR DESCRIPTION
Copybara Docker images uses a wrapper script instead of directly passing
arguments to Copybara itself, in order to set arguments for the JVM.
The script is receiving its arguments through environment variable,
instead of commandline args.